### PR TITLE
ci(commitlint): disable when dependabot is detected

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,7 +9,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: commitlint
+      - if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/') == false)
+        name: commitlint
         uses: wagoid/commitlint-github-action@v2
         with:
           helpURL: https://www.conventionalcommits.org/


### PR DESCRIPTION
Refs https://github.com/wagoid/commitlint-github-action/issues/69, https://github.com/dependabot/dependabot-core/issues/2445, https://github.com/americanexpress/one-app/pull/295.