### PR TITLE
build(docs): upgrade typedoc from 0.19 to 0.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,18 @@
         "node": ">=10.0.0"
       }
     },
+    "../typedoc-plugin-rename-defaults": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "typedoc": "^0.20.29",
+        "typescript": "^4.2.0"
+      },
+      "peerDependencies": {
+        "typedoc": "0.20.x"
+      }
+    },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.0.0-alpha.44",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.44.tgz",
@@ -7739,9 +7751,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -9447,6 +9459,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-typedoc": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.10.0.tgz",
+      "integrity": "sha512-cztkkhJeiZLrGmO4/lI3wLsOqDgJkRwK5WOO+eRko59UP9N3CqTcQoNRDr4ADUO0GZm8jvRT2NBTON5Q1+RVEw==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.20.19",
+        "typedoc-plugin-markdown": ">=3.4.0"
       }
     },
     "node_modules/dom-converter": {
@@ -12304,15 +12326,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "node_modules/highlight.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/history": {
       "version": "4.10.1",
@@ -22211,6 +22224,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^5.1.1"
+      }
+    },
+    "node_modules/onigasm/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/onigasm/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
     "node_modules/open": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -27645,6 +27682,16 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/shiki": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "dev": true,
+      "dependencies": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -29545,14 +29592,70 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.20.29",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.29.tgz",
+      "integrity": "sha512-IyzrbtwNAXtylUJn41FbopQsNSQ1jcM6lUhDL/REOFo31G3Q9fsniZUQP+tIcTX5JaCntRdw3PTMZTQPV52low==",
+      "dev": true,
+      "dependencies": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "^2.0.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.8"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 10.8.0"
+      },
+      "peerDependencies": {
+        "typescript": "3.9.x || 4.0.x || 4.1.x || 4.2.x"
+      }
+    },
     "node_modules/typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.8.tgz",
+      "integrity": "sha512-tyjyDTKy/JLnBSwvhoqd99VIjrP33SdOtwcMD32b+OqnrjZWe8HmZECbfBoacqoxjHd58gfeNw6wA7uvqWFa4w==",
       "dev": true,
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.6.0.tgz",
+      "integrity": "sha512-fg4xby3awJVVxB8TdhHNsZQfiTC5x1XmauVwhKXc6hGeu1bzTnqrkmDT8NCjxfUgw64si8cUX1jBfBjAHthWpQ==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.6"
+      },
+      "engines": {
+        "node": ">= 10.8.0"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.20.0"
+      }
+    },
+    "node_modules/typedoc-plugin-merge-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-1.0.0.tgz",
+      "integrity": "sha512-k/A/YMWy5+E3Wmvoq+7a6H0mHRSfN80Hn8aOZJaWpL7AAtGeSLSCDE9COfXAi/aapZYeatp88JKhJW7lu8+TCQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.20.x"
+      }
+    },
+    "node_modules/typedoc-plugin-rename-defaults": {
+      "resolved": "../typedoc-plugin-rename-defaults",
+      "link": true
     },
     "node_modules/typescript": {
       "version": "4.2.3",
@@ -30326,6 +30429,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -32392,102 +32501,11 @@
         "clsx": "^1.1.1"
       },
       "devDependencies": {
-        "docusaurus-plugin-typedoc": "^0.4.1",
-        "typedoc": "^0.19.2",
-        "typedoc-plugin-markdown": "~3.1.1",
-        "typedoc-plugin-no-inherit": "^1.2.2"
-      }
-    },
-    "website/node_modules/docusaurus-plugin-typedoc": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.4.1.tgz",
-      "integrity": "sha512-hvKF7fXuvZvgFhDVHQuetedzFMpfLOm1bgjJTdhtpz1Y7jV7BgB2iP85UXSO66I/CzfVQzMPEgElhUUcwIXwCw==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "^9.0.1"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.19.0",
-        "typedoc-plugin-markdown": ">=3.0.0"
-      }
-    },
-    "website/node_modules/marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 8.16.2"
-      }
-    },
-    "website/node_modules/typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
-        "lunr": "^2.3.9",
-        "marked": "^1.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "3.9.x || 4.0.x"
-      }
-    },
-    "website/node_modules/typedoc-plugin-markdown": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.1.1.tgz",
-      "integrity": "sha512-esrSaGw9NeGOR1fixubeSYCtQ9tw1iv7xa6bMvwznjs+jOUEdP0/OBe7l2bbk3PoqhNiFBozBJDo3CpcMJGHnw==",
-      "dev": true,
-      "dependencies": {
-        "handlebars": "^4.7.6"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.19.0 < 0.20.0"
-      }
-    },
-    "website/node_modules/typedoc-plugin-no-inherit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.2.2.tgz",
-      "integrity": "sha512-y25JXvdmk8BzkRyc7SlJzredqgj0J3oAscv8gLdqEgIlOWwnZ+MVd6up2y6O+pJ1S2M3T4fDKEXmJDhdMaXIdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typedoc": ">=0.16.0 <0.20.0"
-      }
-    },
-    "website/node_modules/typescript": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "docusaurus-plugin-typedoc": "^0.10.0",
+        "typedoc": "^0.20.29",
+        "typedoc-plugin-markdown": "^3.6.0",
+        "typedoc-plugin-merge-modules": "^1.0.0",
+        "typedoc-plugin-rename-defaults": "^0.1.0"
       }
     }
   },
@@ -38595,9 +38613,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -39938,6 +39956,13 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "docusaurus-plugin-typedoc": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.10.0.tgz",
+      "integrity": "sha512-cztkkhJeiZLrGmO4/lI3wLsOqDgJkRwK5WOO+eRko59UP9N3CqTcQoNRDr4ADUO0GZm8jvRT2NBTON5Q1+RVEw==",
+      "dev": true,
+      "requires": {}
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -42175,12 +42200,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "highlight.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
-      "dev": true
     },
     "history": {
       "version": "4.10.1",
@@ -49631,6 +49650,32 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
     "open": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -53952,6 +53997,16 @@
       "dev": true,
       "optional": true
     },
+    "shiki": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -55471,11 +55526,53 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.20.29",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.29.tgz",
+      "integrity": "sha512-IyzrbtwNAXtylUJn41FbopQsNSQ1jcM6lUhDL/REOFo31G3Q9fsniZUQP+tIcTX5JaCntRdw3PTMZTQPV52low==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "^2.0.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.8"
+      }
+    },
     "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.8.tgz",
+      "integrity": "sha512-tyjyDTKy/JLnBSwvhoqd99VIjrP33SdOtwcMD32b+OqnrjZWe8HmZECbfBoacqoxjHd58gfeNw6wA7uvqWFa4w==",
       "dev": true
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.6.0.tgz",
+      "integrity": "sha512-fg4xby3awJVVxB8TdhHNsZQfiTC5x1XmauVwhKXc6hGeu1bzTnqrkmDT8NCjxfUgw64si8cUX1jBfBjAHthWpQ==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.6"
+      }
+    },
+    "typedoc-plugin-merge-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-merge-modules/-/typedoc-plugin-merge-modules-1.0.0.tgz",
+      "integrity": "sha512-k/A/YMWy5+E3Wmvoq+7a6H0mHRSfN80Hn8aOZJaWpL7AAtGeSLSCDE9COfXAi/aapZYeatp88JKhJW7lu8+TCQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "typedoc-plugin-rename-defaults": {
+      "version": "file:../typedoc-plugin-rename-defaults",
+      "requires": {
+        "typedoc": "^0.20.29",
+        "typescript": "^4.2.0"
+      }
     },
     "typescript": {
       "version": "4.2.3",
@@ -56038,6 +56135,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -57380,69 +57483,11 @@
         "@docusaurus/preset-classic": "^2.0.0-alpha.70",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
-        "docusaurus-plugin-typedoc": "^0.4.1",
-        "typedoc": "^0.19.2",
-        "typedoc-plugin-markdown": "~3.1.1",
-        "typedoc-plugin-no-inherit": "^1.2.2"
-      },
-      "dependencies": {
-        "docusaurus-plugin-typedoc": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.4.1.tgz",
-          "integrity": "sha512-hvKF7fXuvZvgFhDVHQuetedzFMpfLOm1bgjJTdhtpz1Y7jV7BgB2iP85UXSO66I/CzfVQzMPEgElhUUcwIXwCw==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^9.0.1"
-          }
-        },
-        "marked": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-          "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
-          "dev": true
-        },
-        "typedoc": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-          "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^9.0.1",
-            "handlebars": "^4.7.6",
-            "highlight.js": "^10.2.0",
-            "lodash": "^4.17.20",
-            "lunr": "^2.3.9",
-            "marked": "^1.1.1",
-            "minimatch": "^3.0.0",
-            "progress": "^2.0.3",
-            "semver": "^7.3.2",
-            "shelljs": "^0.8.4",
-            "typedoc-default-themes": "^0.11.4"
-          }
-        },
-        "typedoc-plugin-markdown": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.1.1.tgz",
-          "integrity": "sha512-esrSaGw9NeGOR1fixubeSYCtQ9tw1iv7xa6bMvwznjs+jOUEdP0/OBe7l2bbk3PoqhNiFBozBJDo3CpcMJGHnw==",
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.7.6"
-          }
-        },
-        "typedoc-plugin-no-inherit": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.2.2.tgz",
-          "integrity": "sha512-y25JXvdmk8BzkRyc7SlJzredqgj0J3oAscv8gLdqEgIlOWwnZ+MVd6up2y6O+pJ1S2M3T4fDKEXmJDhdMaXIdQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "typescript": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-          "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
-          "dev": true,
-          "peer": true
-        }
+        "docusaurus-plugin-typedoc": "^0.10.0",
+        "typedoc": "^0.20.29",
+        "typedoc-plugin-markdown": "^3.6.0",
+        "typedoc-plugin-merge-modules": "^1.0.0",
+        "typedoc-plugin-rename-defaults": "^0.1.0"
       }
     },
     "websocket-driver": {

--- a/src/commands/save-image.ts
+++ b/src/commands/save-image.ts
@@ -3,9 +3,6 @@ import * as Listr from "listr";
 import * as chalk from "chalk";
 import Image from "../model/image";
 
-/**
- * @noInheritDoc
- */
 export default class SaveImage extends Command {
   static description = "save a docker image to a tgz file";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module
+ * @hidden
+ */
 export { run } from "@oclif/command";

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,13 +49,16 @@ module.exports = {
     [
       "docusaurus-plugin-typedoc",
       {
-        inputFiles: ["../src/"],
+        entryPoints: ["../src/"],
+        tsconfig: "../tsconfig.json",
         docsRoot: "../docs",
-        mode: "file",
         readme: "none",
         name: `${title} API`,
         includeVersion: true,
-        plugin: ["typedoc-plugin-no-inherit"],
+        plugin: [
+          "typedoc-plugin-merge-modules",
+          "typedoc-plugin-rename-defaults",
+        ],
         sidebar: {
           globalsLabel: "Table of Contents",
         },

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,13 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1"
   },
+  "devDependencies": {
+    "docusaurus-plugin-typedoc": "^0.10.0",
+    "typedoc": "^0.20.29",
+    "typedoc-plugin-markdown": "^3.6.0",
+    "typedoc-plugin-merge-modules": "^1.0.0",
+    "typedoc-plugin-rename-defaults": "^0.1.0"
+  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -27,12 +34,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "docusaurus-plugin-typedoc": "^0.4.1",
-    "typedoc": "^0.19.2",
-    "typedoc-plugin-markdown": "~3.1.1",
-    "typedoc-plugin-no-inherit": "^1.2.2"
   },
   "volta": {
     "extends": "../package.json"


### PR DESCRIPTION
`@noInheritDoc` is removed because of https://github.com/jonchardy/typedoc-plugin-no-inherit/issues/20.